### PR TITLE
Allow rules without versions

### DIFF
--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -33,7 +33,7 @@ def info(message, file=sys.stdout):
 
 
 def standards_latest(standards):
-    return max([standard.version for standard in standards if standard.version], key=LooseVersion)
+    return max([standard.version for standard in standards if standard.version] or ["0.1"], key=LooseVersion)
 
 
 def lines_ranges(lines_spec):


### PR DESCRIPTION
The provided examples don't work because they are missing versions. Currently generates this traceback:

```
Traceback (most recent call last):
  File ".../env/bin/ansible-review", line 77, in <module>
    sys.exit(main(sys.argv[1:]))
  File ".../env/bin/ansible-review", line 70, in main
    errors = errors + candidate.review(options, lines)
  File ".../env/local/lib/python2.7/site-packages/ansiblereview/__init__.py", line 68, in review
    return utils.review(self, settings, lines)
  File ".../env/local/lib/python2.7/site-packages/ansiblereview/utils/__init__.py", line 75, in review
    candidate.version = standards_latest(standards.standards)
  File ".../env/local/lib/python2.7/site-packages/ansiblereview/utils/__init__.py", line 36, in standards_latest
    return max([standard.version for standard in standards if standard.version], key=LooseVersion)
ValueError: max() arg is an empty sequence
```

Or, if you would prefer, maybe the fix is to update this line:
```python
max([standard.version for standard in standards if standard.version], key=LooseVersion)
```

It could fall back to some default version number:
```python
max([standard.version for standard in standards if standard.version] or ["0.1"], key=LooseVersion)
```