### PR TITLE
Allow custom configuration file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ your operating system)
 
 The location can be found by using `ansible-review` with no arguments.
 
+You can override the configuration file location with the `-c` flag.
+
 ```
 [rules]
 lint = /path/to/your/ansible/lint/rules
@@ -127,5 +129,3 @@ The type can be inferred from the class name (i.e. `type(candidate).__name__`)
 The ansiblelint check is ready out of the box, and just takes a list of
 IDs or tags to check. You can point to your own ansible-lint rules
 using the configuration file or `-d /path/to/ansible/lint/rules`
-
-

--- a/bin/ansible-review
+++ b/bin/ansible-review
@@ -7,6 +7,7 @@ import sys
 from ansiblereview.version import __version__
 from ansiblereview import classify
 from ansiblereview.utils import error, info, warn, read_config
+from appdirs import AppDirs
 
 
 def get_candidates_from_diff(difftext):
@@ -29,24 +30,33 @@ def get_candidates_from_diff(difftext):
 
 
 def main(args):
-    settings = read_config()
+    config_dir = AppDirs("ansible-review", "com.github.willthames").user_config_dir
+    default_config_file = os.path.join(config_dir, "config.ini")
+
     parser = optparse.OptionParser("%prog playbook_file|role_file|inventory_file",
                                    version="%prog " + __version__)
+    parser.add_option('-c', dest='configfile', default=default_config_file,
+                      help="Location of configuration file: [%s]" % default_config_file)
     parser.add_option('-d', dest='rulesdir',
-                      help="Location of standards rules: [%s]" % settings.rulesdir,
-                      default=settings.rulesdir)
+                      help="Location of standards rules")
     parser.add_option('-r', dest='lintdir',
-                      help="Location of additional lint rules: [%s]" % settings.lintdir,
-                      default=settings.lintdir)
+                      help="Location of additional lint rules")
     parser.add_option('-q', dest='quiet', action="store_true", default=False,
                       help="Only output errors")
-    options, args = parser.parse_args(args)
 
-    if os.path.exists(settings.configfile):
+    options, args = parser.parse_args(args)
+    settings = read_config(options.configfile)
+
+    # Merge CLI options with config options. CLI options override config options.
+    for key, value in settings.__dict__.iteritems():
+        if not getattr(options, key):
+            setattr(options, key, getattr(settings, key))
+
+    if os.path.exists(options.configfile):
         if not options.quiet:
-            info("Using configuration file: %s" % settings.configfile, file=sys.stderr)
+            info("Using configuration file: %s" % options.configfile, file=sys.stderr)
     else:
-        warn("No configuration file found at %s" % settings.configfile, file=sys.stderr)
+        warn("No configuration file found at %s" % options.configfile, file=sys.stderr)
 
     if len(args) == 0:
         candidates = get_candidates_from_diff(sys.stdin)

--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -6,7 +6,6 @@ except ImportError:
     from ansible.color import stringc
 import ansiblereview
 from ansiblereview.version import __version__
-from appdirs import AppDirs
 import ConfigParser
 from distutils.version import LooseVersion
 import importlib
@@ -121,9 +120,7 @@ class Settings(object):
         self.quiet = values.get('quiet', False)
 
 
-def read_config():
-    config_dir = AppDirs("ansible-review", "com.github.willthames").user_config_dir
-    config_file = os.path.join(config_dir, "config.ini")
+def read_config(config_file):
     config = ConfigParser.RawConfigParser({'standards': None, 'lint': None})
     config.read(config_file)
 


### PR DESCRIPTION
This adds a `-c` flag to the CLI to point to custom configuration file location.

This is useful for teams who want to share a configuration file in version control. One small regression is that we can no longer display the default value from the config files for the `-r` and `-d` flags since the configuration file is not known during creation of the help message.

### Before:
```
Usage: ansible-review playbook_file|role_file|inventory_file

Options:
  --version    show program's version number and exit
  -h, --help   show this help message and exit
  -d RULESDIR  Location of standards rules: [None]
  -r LINTDIR   Location of additional lint rules: [None]
  -q           Only output errors
```

### After:
```
Usage: ansible-review playbook_file|role_file|inventory_file

Options:
  --version      show program's version number and exit
  -h, --help     show this help message and exit
  -c CONFIGFILE  Location of configuration file: [/home/user/.config/ansible-
                 review/config.ini]
  -d RULESDIR    Location of standards rules
  -r LINTDIR     Location of additional lint rules
  -q             Only output errors
```
