### PR TITLE
Allow for more fine-grained log levels

### DIFF
--- a/bin/ansible-review
+++ b/bin/ansible-review
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+import logging
 import optparse
 import os
 import sys
@@ -43,6 +44,8 @@ def main(args):
                       help="Location of additional lint rules")
     parser.add_option('-q', dest='quiet', action="store_true", default=False,
                       help="Only output errors")
+    parser.add_option('-v', dest='verbose', action="store_true", default=False,
+                      help="Show more verbose output")
 
     options, args = parser.parse_args(args)
     settings = read_config(options.configfile)
@@ -52,11 +55,17 @@ def main(args):
         if not getattr(options, key):
             setattr(options, key, getattr(settings, key))
 
-    if os.path.exists(options.configfile):
-        if not options.quiet:
-            info("Using configuration file: %s" % options.configfile, file=sys.stderr)
+    if options.verbose:
+        options.log_level = logging.INFO
+    elif options.quiet:
+        options.log_level = logging.ERROR
     else:
-        warn("No configuration file found at %s" % options.configfile, file=sys.stderr)
+        options.log_level = logging.WARNING
+
+    if os.path.exists(options.configfile):
+        info("Using configuration file: %s" % options.configfile, options, file=sys.stderr)
+    else:
+        warn("No configuration file found at %s" % options.configfile, options, file=sys.stderr)
 
     if len(args) == 0:
         candidates = get_candidates_from_diff(sys.stdin)
@@ -72,14 +81,12 @@ def main(args):
         candidate = classify(filename)
         if candidate:
             if lines:
-                if not options.quiet:
-                    info("Reviewing %s lines %s" % (candidate, lines))
+                info("Reviewing %s lines %s" % (candidate, lines), options)
             else:
-                if not options.quiet:
-                    info("Reviewing all of %s" % candidate)
+                info("Reviewing all of %s" % candidate, options)
             errors = errors + candidate.review(options, lines)
         else:
-            warn("Couldn't classify file %s" % filename)
+            warn("Couldn't classify file %s" % filename, options)
     return errors
 
 

--- a/lib/ansiblereview/playbook.py
+++ b/lib/ansiblereview/playbook.py
@@ -5,38 +5,38 @@ from collections import defaultdict
 import os
 
 
-def install_roles(playbook):
-
+def install_roles(playbook, settings):
     rolesdir = os.path.join(os.path.dirname(playbook), "roles")
     rolesfile = os.path.join(os.path.dirname(playbook), "rolesfile.yml")
     if not os.path.exists(rolesfile):
         rolesfile = os.path.join(os.path.dirname(playbook), "rolesfile")
     if os.path.exists(rolesfile):
-        utils.info("Installing roles: Using rolesfile %s and roles dir %s" % (rolesfile, rolesdir))
+        utils.info("Installing roles: Using rolesfile %s and roles dir %s" % (rolesfile, rolesdir),
+                   settings)
         result = utils.execute(["ansible-galaxy", "install", "-r", rolesfile, "-p", rolesdir])
         if result.rc:
             utils.error("Could not install roles from %s:\n%s" %
                         (rolesdir, result.output))
         else:
-            utils.info(u"Roles installed \u2713")
+            utils.info(u"Roles installed \u2713", settings)
     else:
         utils.warn("No roles file found for playbook %s, tried %s and %s.yml" %
-                   (playbook, rolesfile, rolesfile))
+                   (playbook, rolesfile, rolesfile), settings)
 
 
-def syntax_check(playbook):
+def syntax_check(playbook, settings):
     result = utils.execute(["ansible-playbook", "--syntax-check", playbook])
     if result.rc:
         message = "FATAL: Playbook syntax check failed for %s:\n%s" % \
             (playbook, result.output)
         utils.abort(message)
     else:
-        utils.info("Playbook syntax check succeeded for %s" % playbook)
+        utils.info("Playbook syntax check succeeded for %s" % playbook, settings)
 
 
 def review(playbook, settings):
-    install_roles(playbook)
-    syntax_check(playbook)
+    install_roles(playbook, settings)
+    syntax_check(playbook, settings)
     return utils.review(Playbook(playbook), settings)
 
 


### PR DESCRIPTION
Fixes https://github.com/willthames/ansible-review/issues/6 by adding a `-v` flag for verbose logging. The `-q` flag has been updated to only print errors.

#### Default (`WARN`):
```
$ ansible-review test/test_cases/test_role_unversioned/
WARN: Couldn't classify file test/test_cases/test_role_unversioned/
```

#### Verbose (`INFO`):
```
$ ansible-review -v test/test_cases/test_role_unversioned/
INFO: Using configuration file: custom_config.ini
WARN: Couldn't classify file test/test_cases/test_role_unversioned/
```

#### Quiet (`ERROR`):
```
$ ansible-review -q test/test_cases/test_role_unversioned/
```