### PR TITLE
Check for Powershell files

### DIFF
--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -149,6 +149,14 @@ class Code(Unversioned):
     pass
 
 
+class PythonCode(Code):
+    pass
+
+
+class PowershellCode(Code):
+    pass
+
+
 class Template(RoleFile):
     pass
 
@@ -184,9 +192,15 @@ def classify(filename):
         return HostVars(filename)
     if parentdir == 'meta':
         return Meta(filename)
-    if parentdir in ['library', 'lookup_plugins', 'callback_plugins',
-                     'filter_plugins'] or filename.endswith('.py'):
+    if parentdir in ['library'] and filename.endswith('.ps1'):
+        return PowershellCode(filename)
+    elif parentdir in ['library'] and filename.endswith('.py'):
+        return PythonCode(filename)
+    elif parentdir in ['library']:
         return Code(filename)
+    if parentdir in ['lookup_plugins', 'callback_plugin',
+                     'filter_plugins'] or filename.endswith('.py'):
+        return PythonCode(filename)
     if parentdir in ['inventory']:
         return Inventory(filename)
     if 'rolesfile' in filename or 'requirements' in filename:

--- a/lib/ansiblereview/examples/standards.py
+++ b/lib/ansiblereview/examples/standards.py
@@ -121,7 +121,7 @@ inventory_hostfiles_should_not_contain_vars = Standard(dict(
 code_should_meet_flake8 = Standard(dict(
     name="Python code should pass flake8",
     check=code_passes_flake8,
-    types=["code"]
+    types=["pythoncode"]
 ))
 
 tasks_are_named = Standard(dict(

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -21,7 +21,7 @@
 import os
 import unittest
 
-from ansiblereview import Playbook, Task, Code
+from ansiblereview import Playbook, Task, PythonCode
 import ansiblereview.code as code
 
 
@@ -40,6 +40,6 @@ class TestUtils(unittest.TestCase):
 
     def test_code_passes_flake8(self):
         # run flake8 against this source file
-        candidate = Code(__file__.replace('.pyc', '.py'))
+        candidate = PythonCode(__file__.replace('.pyc', '.py'))
         result = code.code_passes_flake8(candidate, None)
         self.assertEqual(len(result.errors), 0)


### PR DESCRIPTION
Currently ansible-review will fail if we run the standard flake8 check on powershell files. As there is no standard set right now for how to handle PS scripts I am proposing we just have a blanket ignore for these files.

Open for suggestions on improvements but this is what I have come up with.