### PR TITLE
Update the README usage section to be more explicit about folders & files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ export PATH=$PATH:`pwd`/ansible-review/bin
 # Usage
 
 ```
-ansible-review reviewtarget [target2...]
+ansible-review FILES
+```
+
+Where FILES is a space delimited list of files to review.
+ansible-review is _not_ recursive and won't descend 
+into child folders; it just processes the list of files you give it.
+
+Passing a folder in with the list of files will elicit a warning:
+
+```
+WARN: Couldn't classify file ./foldername
 ```
 
 ansible-review will review inventory files, role
@@ -42,13 +52,23 @@ files, python code (modules, plugins) and playbooks.
 
 ## Typical approaches
 
+### Git repositories
+
 * `git ls-files | xargs ansible-review` works well in
   a roles repo to review the whole role. But it will
   review the whole of other repos too.
 * `git diff branch_to_compare | ansible-review` will
   review only the changes between the branches and
   surrounding context.
+  
+### Without git
 
+* `find . -type f | xargs ansible-review` will review
+  all files in the current folder (and all subfolders),
+  even if they're not checked into git
+* `ansible-review ./*` will review all the files in the
+  current folder (but not subfolders: bash will expand the
+  `./*` glob into a list of files in the current folder).
 
 # Reviews
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ files, python code (modules, plugins) and playbooks.
 * `find . -type f | xargs ansible-review` will review
   all files in the current folder (and all subfolders),
   even if they're not checked into git
-* `ansible-review ./*` will review all the files in the
-  current folder (but not subfolders: bash will expand the
-  `./*` glob into a list of files in the current folder).
 
 # Reviews
 


### PR DESCRIPTION
Be more explicit about how `ansible-review` handles the files & folders you pass on the command line. Also include some more example usages, including non-git options.

I said `Where FILES is a space delimited list of files to review.` - but realised afterwards that this _might_ be shell specific, or depend on your `IFS` (which defaults to space on bash). Not sure what shells/platforms ansible-review targets, or is rested on.