### PR TITLE
Updating module_loader import path to support Ansible 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.13.3
+* Import module_loader from ansible.plugins.loader for ansible2.4
+
 ### 0.13.2
 * Move to yaml.safe_load to avoid code execution
 
@@ -13,7 +16,7 @@
 
 ### 0.12.3
 * python3 compatibility
-*
+
 ### 0.12.2
 * ansible-review should respect command line parameters
   for lint and standards directories even if config is not

--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -6,9 +6,13 @@ import os
 from ansiblereview import utils
 
 try:
-    from ansible.plugins import module_loader
+    # Ansible 2.4 import of module loader
+    from ansible.plugins.loader import module_loader
 except ImportError:
-    from ansible.utils import module_finder as module_loader
+    try:
+        from ansible.plugins import module_loader
+    except ImportError:
+        from ansible.utils import module_finder as module_loader
 
 
 class AnsibleReviewFormatter(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27-ansible{19,20,21,22,devel},py34-ansible{22,devel},flake8
+envlist = py27-ansible{19,20,21,22,23,24,devel},py34-ansible{22,devel},flake8
 
 [testenv]
 deps =
@@ -8,6 +8,8 @@ deps =
   ansible20: ansible>=2.0.0.2,<2.1
   ansible21: ansible>=2.1,<2.2
   ansible22: ansible>=2.2,<2.3
+  ansible23: ansible>=2.3,<2.4
+  ansible24: ansible>=2.4,<2.5
   ansibledevel: git+https://github.com/ansible/ansible.git
   ansible-lint>=3.0.0
   -rtest-deps.txt


### PR DESCRIPTION
I encountered the following issue when running `ansible-review --version` against Ansible 2.4.

```
ansible-review --version
Traceback (most recent call last):
  File "/usr/local/bin/ansible-review", line 7, in <module>
    from ansiblereview.main import main
  File "/usr/local/lib/python2.7/dist-packages/ansiblereview/__init__.py", line 11, in <module>
    from ansible.utils import module_finder as module_loader
```

This PR fixes the issue (validated by tox). I am not sure if nested try, excepts are the best way to go about this however using `ansible.__version__` felt a little more unreliable.