### PR TITLE
subprocess output is bytes not str on Python 3

### DIFF
--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -167,8 +167,11 @@ class ExecuteResult(object):
 
 def execute(cmd):
     result = ExecuteResult()
+    encoding = 'UTF-8'
+    env = dict(os.environ)
+    env['PYTHONIOENCODING'] = encoding
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
-    result.output = proc.communicate()[0]
+                            stderr=subprocess.STDOUT, env=env)
+    result.output = proc.communicate()[0].decode(encoding)
     result.rc = proc.returncode
     return result


### PR DESCRIPTION
This is not currently covered by the test suite because there is
normally no flake8 output to be parsed when it passes. I hit this
because flake8 itself broke for unrelated reasons (RHBZ#1582075).