### PR TITLE
Added the flake8 block read functionality 

### DIFF
--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -43,6 +43,8 @@ def main():
                       help="Location of standards rules")
     parser.add_option('-r', dest='lintdir',
                       help="Location of additional lint rules")
+    parser.add_option('--max-line-length', dest='maxlinelength',
+                      help="Flake8 max line length")
     parser.add_option('-q', dest='log_level', action="store_const", default=logging.WARN,
                       const=logging.ERROR, help="Only output errors")
     parser.add_option('-s', dest='standards_filter', action='append',
@@ -55,6 +57,7 @@ def main():
 
     # Merge CLI options with config options. CLI options override config options.
     for key, value in settings.__dict__.iteritems():
+        #print("Setting " + str(key) + " = " + str(value))
         if not getattr(options, key):
             setattr(options, key, getattr(settings, key))
 

--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -57,7 +57,6 @@ def main():
 
     # Merge CLI options with config options. CLI options override config options.
     for key, value in settings.__dict__.iteritems():
-        #print("Setting " + str(key) + " = " + str(value))
         if not getattr(options, key):
             setattr(options, key, getattr(settings, key))
 

--- a/lib/ansiblereview/code.py
+++ b/lib/ansiblereview/code.py
@@ -2,7 +2,7 @@ from ansiblereview import Error, Result, utils
 
 
 def code_passes_flake8(candidate, options):
-    result = utils.execute(["flake8", candidate.path])
+    result = utils.execute(["flake8", "--max-line-length=" + str(options.maxlinelength), candidate.path])
     errors = []
     if result.rc:
         for line in result.output.strip().split('\n'):

--- a/lib/ansiblereview/code.py
+++ b/lib/ansiblereview/code.py
@@ -2,7 +2,12 @@ from ansiblereview import Error, Result, utils
 
 
 def code_passes_flake8(candidate, options):
-    result = utils.execute(["flake8", "--max-line-length=" + str(options.maxlinelength), candidate.path])
+    result = utils.execute(
+        [
+            "flake8",
+            "--max-line-length=" + str(options.maxlinelength),
+            candidate.path
+        ])
     errors = []
     if result.rc:
         for line in result.output.strip().split('\n'):

--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -151,13 +151,15 @@ class Settings(object):
 
 
 def read_config(config_file):
-    config = configparser.RawConfigParser({'standards': None, 'lint': None, 'max-line-length': None})
+    config = configparser.RawConfigParser({
+        'standards': None,
+        'lint': None,
+        'max-line-length': '79'
+        })
     config.read(config_file)
 
     if config.has_section('flake8'):
-        max_line_length=config.get('flake8', 'max-line-length')
-    else:
-        max_line_length="79"
+        max_line_length = config.get('flake8', 'max-line-length')
 
     if config.has_section('rules'):
         return Settings(dict(rulesdir=config.get('rules', 'standards'),
@@ -165,7 +167,14 @@ def read_config(config_file):
                              maxlinelength=max_line_length,
                              configfile=config_file))
     else:
-        return Settings(dict(rulesdir=None, lintdir=None, maxlinelength=max_line_length, configfile=config_file))
+        return Settings(
+                dict(
+                    rulesdir=None,
+                    lintdir=None,
+                    maxlinelength=max_line_length,
+                    configfile=config_file
+                    )
+                )
 
 
 class ExecuteResult(object):

--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -147,18 +147,25 @@ class Settings(object):
         self.rulesdir = values.get('rulesdir')
         self.lintdir = values.get('lintdir')
         self.configfile = values.get('configfile')
+        self.maxlinelength = values.get('maxlinelength')
 
 
 def read_config(config_file):
-    config = configparser.RawConfigParser({'standards': None, 'lint': None})
+    config = configparser.RawConfigParser({'standards': None, 'lint': None, 'max-line-length': None})
     config.read(config_file)
+
+    if config.has_section('flake8'):
+        max_line_length=config.get('flake8', 'max-line-length')
+    else:
+        max_line_length="79"
 
     if config.has_section('rules'):
         return Settings(dict(rulesdir=config.get('rules', 'standards'),
                              lintdir=config.get('rules', 'lint'),
+                             maxlinelength=max_line_length,
                              configfile=config_file))
     else:
-        return Settings(dict(rulesdir=None, lintdir=None, configfile=config_file))
+        return Settings(dict(rulesdir=None, lintdir=None, maxlinelength=max_line_length, configfile=config_file))
 
 
 class ExecuteResult(object):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -41,5 +41,5 @@ class TestUtils(unittest.TestCase):
     def test_code_passes_flake8(self):
         # run flake8 against this source file
         candidate = Code(__file__.replace('.pyc', '.py'))
-        result = code.code_passes_flake8(candidate, None)
+        result = code.code_passes_flake8(candidate, '100', None)
         self.assertEqual(len(result.errors), 0)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -24,9 +24,6 @@ import unittest
 from ansiblereview import Playbook, Task, Code
 import ansiblereview.code as code
 
-class options(object):
-    maxlinelength = '79'
-
 class TestUtils(unittest.TestCase):
     def setUp(self):
         self.cwd = os.path.dirname(__file__)

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -24,6 +24,8 @@ import unittest
 from ansiblereview import Playbook, Task, Code
 import ansiblereview.code as code
 
+class options(object):
+    maxlinelength = '79'
 
 class TestUtils(unittest.TestCase):
     def setUp(self):

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -41,5 +41,5 @@ class TestUtils(unittest.TestCase):
     def test_code_passes_flake8(self):
         # run flake8 against this source file
         candidate = Code(__file__.replace('.pyc', '.py'))
-        result = code.code_passes_flake8(candidate, '100', None)
+        result = code.code_passes_flake8(candidate, None)
         self.assertEqual(len(result.errors), 0)


### PR DESCRIPTION
Currently, there is a max-line-length option (among others) in setup.cfg for flake8 , but there is no code to read it , as [rules] is actually the only block being read from the config file. I've added the needed code to get flake8 block read and max-line-length included in options dict so it can be passed along to flake8 when executed