### PR TITLE
include test/diff.txt in tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.md
 include LICENSE
-recursive-include test *.py *.yml hosts
+recursive-include test *.py *.yml *.txt hosts
 recursive-include lib/ansiblereview/examples *.py


### PR DESCRIPTION
This file is currently missing, which causes the tests to fail:

    ======================================================================
    ERROR: test_diff_encoding (TestDiffEncoding.TestDiffEncoding)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "ansible-review-0.13.6/test/TestDiffEncoding.py", line 12, in test_diff_encoding
        with io.open(os.path.join(self.directory, 'diff.txt'), 'r') as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'ansible-review-0.13.6/test/diff.txt'