### PR TITLE
Pluggable output handlers + JSON structured log handler

### DIFF
--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -72,8 +72,8 @@ class Candidate(object):
         self.filetype = type(self).__name__.lower()
         self.expected_version = True
 
-    def review(self, settings, lines=None):
-        return utils.review(self, settings, lines)
+    def review(self, settings, lines=None, display=None):
+        return utils.review(self, settings, lines, display=display)
 
     def __repr__(self):
         return "%s (%s)" % (type(self).__name__, self.path)

--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -1,8 +1,11 @@
-from ansiblelint import default_rulesdir, RulesCollection
 import codecs
-from functools import partial
-import re
 import os
+import re
+
+from functools import partial
+from six import iteritems
+
+from ansiblelint import default_rulesdir, RulesCollection
 from ansiblereview import utils
 
 try:
@@ -40,15 +43,27 @@ class Standard(object):
 
 
 class Error(object):
-    def __init__(self, lineno, message):
+    def __init__(self, lineno, message, error_type=None, **kwargs):
         self.lineno = lineno
         self.message = message
+        self.error_type = error_type
+        self.kwargs = kwargs
+        for (key, value) in iteritems(kwargs):
+            setattr(self, key, value)
 
     def __repr__(self):
         if self.lineno:
             return "%s: %s" % (self.lineno, self.message)
         else:
             return self.message
+
+    def to_dict(self):
+        result = dict(lineno=self.lineno, message=self.message)
+        if self.error_type:
+            result['error_type'] = self.error_type
+        for (key, value) in iteritems(self.kwargs):
+            result[key] = value
+        return result
 
 
 class Result(object):
@@ -218,11 +233,12 @@ def ansiblelint(rulename, candidate, settings):
     rules.extend(RulesCollection.create_from_directory(default_rulesdir))
     if settings.lintdir:
         rules.extend(RulesCollection.create_from_directory(settings.lintdir))
-
     fileinfo = dict(path=candidate.path, type=candidate.filetype)
     matches = rules.run(fileinfo, rulename.split(','))
-    result.errors = [Error(match.linenumber, "[%s] %s" % (match.rule.id, match.message))
-                     for match in matches]
+    result.errors = [
+        Error(match.linenumber, "[%s] %s" % (match.rule.id, match.message),
+              'ansiblelint', error_rule=match.rule.id, error_msg=match.message)
+        for match in matches]
     return result
 
 

--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -7,10 +7,9 @@ import os
 import sys
 from ansiblereview.version import __version__
 from ansiblereview import classify
-from ansiblereview.utils import info, warn, read_config
-from appdirs import AppDirs
+from ansiblereview.utils import read_config, get_default_config
 from pkg_resources import resource_filename
-
+from ansiblereview.display import load_display_handler
 
 def get_candidates_from_diff(difftext):
     try:
@@ -32,9 +31,7 @@ def get_candidates_from_diff(difftext):
 
 
 def main():
-    config_dir = AppDirs("ansible-review", "com.github.willthames").user_config_dir
-    default_config_file = os.path.join(config_dir, "config.ini")
-
+    default_config_file = get_default_config()
     parser = optparse.OptionParser("%prog playbook_file|role_file|inventory_file",
                                    version="%prog " + __version__)
     parser.add_option('-c', dest='configfile', default=default_config_file,
@@ -49,27 +46,29 @@ def main():
                       help="limit standards to specific names")
     parser.add_option('-v', dest='log_level', action="store_const", default=logging.WARN,
                       const=logging.INFO, help="Show more verbose output")
-
+    
     options, args = parser.parse_args(sys.argv[1:])
     settings = read_config(options.configfile)
 
+    display = load_display_handler('default', __name__, options.log_level)
+    
     # Merge CLI options with config options. CLI options override config options.
-    for key, value in settings.__dict__.items():
+    for key, _ in settings.__dict__.items():
         if not getattr(options, key):
             setattr(options, key, getattr(settings, key))
 
     if os.path.exists(options.configfile):
-        info("Using configuration file: %s" % options.configfile, options)
+        display.info("Using configuration file: %s" % options.configfile, options)
     else:
-        warn("No configuration file found at %s" % options.configfile, options, file=sys.stderr)
+        display.warn("No configuration file found at %s" % options.configfile)
         if not options.rulesdir:
             rules_dir = os.path.join(resource_filename('ansiblereview', 'examples'))
-            warn("Using example standards found at %s" % rules_dir, options, file=sys.stderr)
+            display.warn("Using example standards found at %s" % rules_dir)
             options.rulesdir = rules_dir
         if not options.lintdir:
             lint_dir = os.path.join(options.rulesdir, 'lint-rules')
             if os.path.exists(lint_dir):
-                warn("Using example lint-rules found at %s" % lint_dir, options, file=sys.stderr)
+                display.warn("Using example lint-rules found at %s" % lint_dir)
                 options.lintdir = lint_dir
 
     if len(args) == 0:
@@ -86,13 +85,13 @@ def main():
         candidate = classify(filename)
         if candidate:
             if candidate.binary:
-                warn("Not reviewing binary file %s" % filename, options)
+                display.warn("Not reviewing binary file %s" % filename)
                 continue
             if lines:
-                info("Reviewing %s lines %s" % (candidate, lines), options)
+                display.info("Reviewing %s lines %s" % (candidate, lines))
             else:
-                info("Reviewing all of %s" % candidate, options)
-            errors = errors + candidate.review(options, lines)
+                display.info("Reviewing all of %s" % candidate)
+            errors = errors + candidate.review(options, lines, display=display)
         else:
-            info("Couldn't classify file %s" % filename, options)
+            display.info("Couldn't classify file %s" % filename)
     return errors

--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -62,7 +62,7 @@ def main():
             setattr(options, key, getattr(settings, key))
 
     if os.path.exists(options.configfile):
-        display.info("Using configuration file: %s" % options.configfile, options,
+        display.info("Using configuration file: %s" % options.configfile,
                      tag="config")
     else:
         display.warn("No configuration file found at %s" % options.configfile,

--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -62,7 +62,7 @@ def main():
             setattr(options, key, getattr(settings, key))
 
     if os.path.exists(options.configfile):
-        display.info("Using configuration file: %s" % options.configfile,
+        display.info("Using configuration file: %s" % (options.configfile,),
                      tag="config")
     else:
         display.warn("No configuration file found at %s" % options.configfile,
@@ -93,13 +93,18 @@ def main():
         candidate = classify(filename)
         if candidate:
             if candidate.binary:
-                display.warn("Not reviewing binary file %s" % filename)
+                display.warn("Not reviewing binary file %s" % filename,
+                             tag='skipped', file=filename)
                 continue
             if lines:
-                display.info("Reviewing %s lines %s" % (candidate, lines))
+                display.info("Reviewing %s lines %s" % (candidate, lines),
+                             tag='started', review_type='lines')
             else:
-                display.info("Reviewing all of %s" % candidate)
+                display.info("Reviewing all of %s" % candidate,
+                             tag="started", review_type='file',
+                             file=filename)
             errors = errors + candidate.review(options, lines, display=display)
         else:
-            display.info("Couldn't classify file %s" % filename)
+            display.info("Couldn't classify file %s" % filename,
+                         tag="unclassifed", file=filename)
     return errors

--- a/lib/ansiblereview/display/__init__.py
+++ b/lib/ansiblereview/display/__init__.py
@@ -1,7 +1,14 @@
 import logging
 import importlib
 
+DISPLAY_NAMES = [
+    'default',
+    'json'
+]
+
 
 def load_display_handler(handler_name, name, level=logging.ERROR):
+    if handler_name not in DISPLAY_NAMES:
+        raise SystemExit
     mod = importlib.import_module('.display.%s' % handler_name, package='ansiblereview')
-    return mod.Display(name, level=level).get_handler()
+    return mod.Display(name, level=level)

--- a/lib/ansiblereview/display/__init__.py
+++ b/lib/ansiblereview/display/__init__.py
@@ -8,7 +8,5 @@ DISPLAY_NAMES = [
 
 
 def load_display_handler(handler_name, name, level=logging.ERROR):
-    if handler_name not in DISPLAY_NAMES:
-        raise SystemExit
     mod = importlib.import_module('.display.%s' % handler_name, package='ansiblereview')
     return mod.Display(name, level=level)

--- a/lib/ansiblereview/display/__init__.py
+++ b/lib/ansiblereview/display/__init__.py
@@ -1,0 +1,7 @@
+import logging
+import importlib
+
+
+def load_display_handler(handler_name, name, level=logging.ERROR):
+    mod = importlib.import_module('.display.%s' % handler_name, package='ansiblereview')
+    return mod.Display(name, level=level).get_handler()

--- a/lib/ansiblereview/display/base.py
+++ b/lib/ansiblereview/display/base.py
@@ -6,7 +6,20 @@ class BaseDisplay(object):
     def __init__(self, name, level=logging.ERROR):
         self.name = name
         self.level = level
+        self.logger = self.get_handler()
 
     def get_handler(self):
         """ Returns a configured display or logging handler"""
+        raise NotImplementedError()
+
+    def info(self, msg, **kwargs):
+        """ Handle info messages """
+        raise NotImplementedError()
+
+    def warn(self, msg, **kwargs):
+        """ Handle warning messages """
+        raise NotImplementedError()
+
+    def error(self, msg, **kwargs):
+        """ Handle error messages """
         raise NotImplementedError()

--- a/lib/ansiblereview/display/base.py
+++ b/lib/ansiblereview/display/base.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class BaseDisplay(object):
+
+    def __init__(self, name, level=logging.ERROR):
+        self.name = name
+        self.level = level
+
+    def get_handler(self):
+        """ Returns a configured display or logging handler"""
+        raise NotImplementedError()

--- a/lib/ansiblereview/display/default.py
+++ b/lib/ansiblereview/display/default.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from ansible.color import stringc
 
- 
+
 class Display(BaseDisplay):
 
     def get_handler(self):
@@ -18,6 +18,16 @@ class Display(BaseDisplay):
         handler.setFormatter(ColoredFormatter('%(message)s'))
         logger.addHandler(handler)
         return logger
+
+    def info(self, msg, **kwargs):
+        self.logger.info(msg)
+
+    def warn(self, msg, **kwargs):
+        self.logger.warn(msg)
+
+    def error(self, msg, **kwargs):
+        self.logger.error(msg)
+
 
 class ColoredFormatter(logging.Formatter):
     def __init__(self, msg):

--- a/lib/ansiblereview/display/default.py
+++ b/lib/ansiblereview/display/default.py
@@ -1,0 +1,34 @@
+import logging
+
+from ansiblereview.display.base import BaseDisplay
+
+try:
+    from ansible.utils.color import stringc
+except ImportError:
+    from ansible.color import stringc
+
+ 
+class Display(BaseDisplay):
+
+    def get_handler(self):
+        logger = logging.getLogger(self.name)
+        logger.setLevel(self.level)
+        handler = logging.StreamHandler()
+        handler.setLevel(self.level)
+        handler.setFormatter(ColoredFormatter('%(message)s'))
+        logger.addHandler(handler)
+        return logger
+
+class ColoredFormatter(logging.Formatter):
+    def __init__(self, msg):
+        logging.Formatter.__init__(self, msg)
+
+    def format(self, record):
+        levelname = record.levelname
+        if levelname == logging.getLevelName(logging.WARNING):
+            record.msg = stringc('WARN: %s' % record.msg, 'yellow')
+        elif levelname == logging.getLevelName(logging.ERROR):
+            record.msg = stringc('ERROR: %s' % record.msg, 'red')
+        elif levelname == logging.getLevelName(logging.INFO):
+            record.msg = stringc('INFO: %s' % record.msg, 'green')
+        return logging.Formatter.format(self, record)

--- a/lib/ansiblereview/display/json.py
+++ b/lib/ansiblereview/display/json.py
@@ -1,0 +1,43 @@
+import logging
+import structlog
+import sys
+
+from ansiblereview.display.base import BaseDisplay
+
+
+class Display(BaseDisplay):
+    def __init__(self, name, level=logging.ERROR):
+        BaseDisplay.__init__(self, name, level)
+        logging.basicConfig(
+            format="%(message)s",
+            level=level,
+            stream=sys.stdout
+        )
+        structlog.configure(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                structlog.processors.JSONRenderer()
+            ],
+            context_class=dict,
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=True,
+        )
+
+    def get_handler(self):
+        return structlog.getLogger(self.name)
+
+    def info(self, msg, **kwargs):
+        return self.logger.info(msg, **kwargs)
+
+    def warn(self, msg, **kwargs):
+        return self.logger.warn(msg, **kwargs)
+
+    def error(self, msg, **kwargs):
+        return self.logger.error(msg, **kwargs)

--- a/lib/ansiblereview/display/json.py
+++ b/lib/ansiblereview/display/json.py
@@ -22,7 +22,7 @@ class Display(BaseDisplay):
                 structlog.processors.StackInfoRenderer(),
                 structlog.processors.format_exc_info,
                 structlog.processors.UnicodeDecoder(),
-                structlog.processors.JSONRenderer()
+                structlog.processors.JSONRenderer(sort_keys=True),
             ],
             context_class=dict,
             logger_factory=structlog.stdlib.LoggerFactory(),

--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -1,43 +1,26 @@
 from __future__ import print_function
 
-try:
-    from ansible.utils.color import stringc
-except ImportError:
-    from ansible.color import stringc
-import ansiblereview
-import ansible
-from ansiblereview.version import __version__
-import ansiblelint.version
-from distutils.version import LooseVersion
 import importlib
 import logging
 import os
 import subprocess
 import sys
 
+from appdirs import AppDirs
+from distutils.version import LooseVersion
+
+import ansible
+import ansiblereview
+from ansiblereview.version import __version__
+from ansiblereview.display import load_display_handler
+
+import ansiblelint.version
+
+
 try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
-
-
-def abort(message, file=sys.stderr):
-    print(stringc("FATAL: %s" % message, 'red'), file=file)
-    sys.exit(1)
-
-
-def error(message, file=sys.stderr):
-    print(stringc("ERROR: %s" % message, 'red'), file=file)
-
-
-def warn(message, settings, file=sys.stdout):
-    if settings.log_level <= logging.WARNING:
-        print(stringc("WARN: %s" % message, 'yellow'), file=file)
-
-
-def info(message, settings, file=sys.stdout):
-    if settings.log_level <= logging.INFO:
-        print(stringc("INFO: %s" % message, 'green'), file=file)
 
 
 def standards_latest(standards):
@@ -61,17 +44,22 @@ def is_line_in_ranges(line, ranges):
 
 def read_standards(settings):
     if not settings.rulesdir:
-        abort("Standards directory is not set on command line or in configuration file - aborting")
+        raise SystemExit("Standards directory is not set on command line or in configuration "
+                         "file - aborting")
     sys.path.append(os.path.abspath(os.path.expanduser(settings.rulesdir)))
     try:
         standards = importlib.import_module('standards')
     except ImportError as e:
-        abort("Could not import standards from directory %s: %s" % (settings.rulesdir, str(e)))
+        raise SystemExit("Could not import standards from directory %s: %s" % 
+                         (settings.rulesdir, str(e)))
     return standards
 
 
-def review(candidate, settings, lines=None):
+def review(candidate, settings, lines=None, display=None):
     errors = 0
+    
+    if not display:
+        display = load_display_handler('default', __name__, logging.ERROR)
 
     standards = read_standards(settings)
     if getattr(standards, 'ansible_min_version', None) and \
@@ -97,20 +85,17 @@ def review(candidate, settings, lines=None):
         candidate.version = standards_latest(standards.standards)
         if candidate.expected_version:
             if isinstance(candidate, ansiblereview.RoleFile):
-                warn("%s %s is in a role that contains a meta/main.yml without a declared "
+                display.warn("%s %s is in a role that contains a meta/main.yml without a declared "
                      "standards version. "
                      "Using latest standards version %s" %
-                     (type(candidate).__name__, candidate.path, candidate.version),
-                     settings)
+                     (type(candidate).__name__, candidate.path, candidate.version))
             else:
-                warn("%s %s does not present standards version. "
+                display.warn("%s %s does not present standards version. "
                      "Using latest standards version %s" %
-                     (type(candidate).__name__, candidate.path, candidate.version),
-                     settings)
+                     (type(candidate).__name__, candidate.path, candidate.version))
 
-    info("%s %s declares standards version %s" %
-         (type(candidate).__name__, candidate.path, candidate.version),
-         settings)
+    display.info("%s %s declares standards version %s" %
+         (type(candidate).__name__, candidate.path, candidate.version))
 
     for standard in standards.standards:
         if type(candidate).__name__.lower() not in standard.types:
@@ -122,22 +107,22 @@ def review(candidate, settings, lines=None):
                     if not err.lineno or
                     is_line_in_ranges(err.lineno, lines_ranges(lines))]:
             if not standard.version:
-                warn("Best practice \"%s\" not met:\n%s:%s" %
-                     (standard.name, candidate.path, err), settings)
+                display.warn("Best practice \"%s\" not met:\n%s:%s" %
+                     (standard.name, candidate.path, err))
             elif LooseVersion(standard.version) > LooseVersion(candidate.version):
-                warn("Future standard \"%s\" not met:\n%s:%s" %
-                     (standard.name, candidate.path, err), settings)
+                display.warn("Future standard \"%s\" not met:\n%s:%s" %
+                     (standard.name, candidate.path, err))
             else:
-                error("Standard \"%s\" not met:\n%s:%s" %
+                display.error("Standard \"%s\" not met:\n%s:%s" %
                       (standard.name, candidate.path, err))
                 errors = errors + 1
         if not result.errors:
             if not standard.version:
-                info("Best practice \"%s\" met" % standard.name, settings)
+                display.info("Best practice \"%s\" met" % standard.name)
             elif LooseVersion(standard.version) > LooseVersion(candidate.version):
-                info("Future standard \"%s\" met" % standard.name, settings)
+                display.info("Future standard \"%s\" met" % standard.name)
             else:
-                info("Standard \"%s\" met" % standard.name, settings)
+                display.info("Standard \"%s\" met" % standard.name)
 
     return errors
 
@@ -149,7 +134,9 @@ class Settings(object):
         self.configfile = values.get('configfile')
 
 
-def read_config(config_file):
+def read_config(config_file=None):
+    if not config_file:
+        config_file = get_default_config()
     config = configparser.RawConfigParser({'standards': None, 'lint': None})
     config.read(config_file)
 
@@ -160,7 +147,10 @@ def read_config(config_file):
     else:
         return Settings(dict(rulesdir=None, lintdir=None, configfile=config_file))
 
-
+def get_default_config():
+    config_dir = AppDirs("ansible-review", "com.github.willthames").user_config_dir
+    return os.path.join(config_dir, "config.ini")
+    
 class ExecuteResult(object):
     pass
 

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -32,9 +32,12 @@ BAD:
 
 
 from __future__ import print_function
+
 import codecs
+import os
 import re
 import sys
+
 from ansiblereview import Result, Error, utils
 
 
@@ -70,7 +73,7 @@ if __name__ == '__main__':
     args = sys.argv[1:] or [sys.stdin]
     rc = 0
     for arg in args:
-        result = yamlreview(arg, utils.Settings())
+        result = yamlreview(arg, utils.Settings(utils.read_config()))
         for error in result.errors():
             print("ERROR: %s:%s: %s" % (arg, error.lineno, error.message), file=sys.stderr)
             rc = 1

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -34,7 +34,6 @@ BAD:
 from __future__ import print_function
 
 import codecs
-import os
 import re
 import sys
 

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -37,7 +37,7 @@ import codecs
 import re
 import sys
 
-from ansiblereview import Result, Error, utils
+from ansiblereview import Error, Result, utils
 
 
 def indent_checker(filename):
@@ -56,9 +56,11 @@ def indent_checker(filename):
             if offset > 0 and offset != 2:
                 if match.group('indent').endswith('- '):
                     errors.append(Error(lineno, "lines starting with '- ' should have same "
-                                  "or less indentation than previous line"))
+                                        "or less indentation than previous line",
+                                  error_type='yamlreview'))
                 else:
-                    errors.append(Error(lineno, "indentation should increase by 2 chars"))
+                    errors.append(Error(lineno, "indentation should increase by 2 chars",
+                                  error_type='yamlreview'))
             prev_indent = curr_indent
         return errors
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages('lib'),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['ansible-lint>=3.4.1', 'pyyaml', 'appdirs', 'unidiff', 'flake8'],
+    install_requires=['ansible-lint>=3.4.1', 'pyyaml', 'appdirs', 'unidiff', 'flake8', 'structlog'],
     entry_points={
         'console_scripts': [
             'ansible-review = ansiblereview.__main__:main'

--- a/test-deps.txt
+++ b/test-deps.txt
@@ -3,3 +3,4 @@ nose
 pep8-naming
 tox
 wheel
+testfixtures

--- a/test/TestJsonOutput.py
+++ b/test/TestJsonOutput.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2013-2014 Will Thames <will@thames.id.au>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import json
+import logging
+import os
+import unittest
+import subprocess
+
+from testfixtures import log_capture
+
+try:
+    from ansible.utils.color import stringc
+except ImportError:
+    from ansible.color import stringc
+
+from ansiblereview import classify, Task
+from ansiblereview.utils import load_display_handler
+import ansiblereview.code as code
+
+
+class Options(object):
+    pass
+
+
+class TestJsonOutput(unittest.TestCase):
+
+    def setUp(self):
+        self.cwd = os.path.dirname(__file__)
+        self.options = Options()
+        self.options.lintdir = os.path.join(self.cwd, '..', 'lib',
+            'ansiblereview', 'examples', 'lint-rules')
+        self.options.rulesdir = os.path.join(self.cwd, 'example_standards')
+        self.options.standards_filter = []
+        self.display = load_display_handler('json', 'testing', logging.DEBUG)
+
+    @log_capture()
+    def test_tag_exists_in_output(self, capture):
+        candidate_path = os.path.join(self.cwd, 'test_cases', 'test_role_errors',
+                                      'tasks', 'main.yml')
+        candidate = classify(candidate_path)
+        candidate.review(self.options, None, display=self.display)
+        for actual in capture.actual():
+            data = json.loads(actual[2])
+            self.assertIsInstance(data, dict)
+            self.assertIn('tag', data)
+
+    @log_capture()
+    def test_ansiblelint_present(self, capture):
+        candidate_path = os.path.join(self.cwd, 'test_cases', 'test_role_errors',
+                                      'tasks', 'main.yml')
+        candidate = classify(candidate_path)
+        candidate.review(self.options, None, display=self.display)
+        count = 0
+        for actual in capture.actual():
+            data = json.loads(actual[2])
+            if ('error_type' in data and data['error_type'] == 'ansiblelint'):
+                count += 1
+                self.assertIn('lineno', data)
+                self.assertIn('error_msg', data)
+                self.assertIn('error_rule', data)
+        self.assertEqual(count, 3)
+    
+    @log_capture()
+    def test_yamlreview_present(self, capture):
+        candidate_path = os.path.join(self.cwd, 'test_cases', 'test_role_errors',
+                                      'defaults', 'main.yml')
+        candidate = classify(candidate_path)
+        candidate.review(self.options, None, display=self.display)
+        count = 0
+        for actual in capture.actual():
+            data = json.loads(actual[2])
+            if ('error_type' in data and data['error_type'] == 'yamlreview'):
+                count += 1
+                self.assertIn('lineno', data)
+                self.assertIn('message', data)
+        self.assertEqual(count, 2)

--- a/test/example_standards/standards.py
+++ b/test/example_standards/standards.py
@@ -1,0 +1,318 @@
+import codecs
+import os
+import yaml
+
+from ansiblereview import Result, Error, Standard, lintcheck
+from ansiblereview.utils.yamlindent import yamlreview
+from ansiblereview.inventory import parse, no_vars_in_host_file
+from ansiblereview.code import code_passes_flake8
+from ansiblereview.vars import repeated_vars
+from ansiblereview.playbook import repeated_names
+from ansiblereview.rolesfile import yamlrolesfile
+from ansiblereview.tasks import yaml_form_rather_than_key_value
+from ansiblereview.groupvars import same_variable_defined_in_competing_groups
+from ansiblelint.utils import parse_yaml_linenumbers
+
+
+def rolesfile_contains_scm_in_src(candidate, settings):
+    result = Result(candidate.path)
+    if candidate.path.endswith(".yml") and os.path.exists(candidate.path):
+        try:
+            with codecs.open(candidate.path, mode='rb', encoding='utf-8') as f:
+                roles = parse_yaml_linenumbers(f.read(), candidate.path)
+            for role in roles:
+                if '+' in role.get('src'):
+                    error = Error(role['__line__'], "Use scm key rather "
+                                  "than src: scm+url")
+                    result.errors.append(error)
+        except Exception as e:
+            result.errors = [Error(None, "Cannot parse YAML from %s: %s" %
+                                   (candidate.path, str(e)))]
+    return result
+
+
+def files_should_have_actual_content(candidate, settings):
+    errors = []
+    with codecs.open(candidate.path, mode='rb', encoding='utf-8') as f:
+        content = yaml.safe_load(f.read())
+    if not content:
+        errors = [Error(None, "%s appears to have no useful content" % candidate)]
+    return Result(candidate.path, errors)
+
+
+def host_vars_exist(candidate, settings):
+    return Result(candidate.path, [Error(None, "Host vars are generally "
+                                         "not required")])
+
+
+def noop(candidate, settings):
+    return Result(candidate.path)
+
+
+rolesfile_should_be_in_yaml = Standard(dict(
+    name="Roles file should be in yaml format",
+    check=yamlrolesfile,
+    types=["rolesfile"]
+))
+
+role_must_contain_meta_main = Standard(dict(
+    name="Roles must contain suitable meta/main.yml",
+    check=lintcheck('EXTRA0012'),
+    types=["meta"]
+))
+
+role_meta_main_must_contain_info = Standard(dict(
+    name="Roles meta/main.yml must contain important info",
+    check=lintcheck('EXTRA0013'),
+    types=["meta"]
+))
+
+variables_should_contain_whitespace = Standard(dict(
+    name="Variable uses should contain whitespace",
+    check=lintcheck('EXTRA0001'),
+    types=["playbook", "task", "handler", "rolevars",
+           "hostvars", "groupvars", "template"]
+))
+
+commands_should_be_idempotent = Standard(dict(
+    name="Commands should be idempotent",
+    check=lintcheck('ANSIBLE0012'),
+    types=["playbook", "task"]
+))
+
+commands_should_not_be_used_in_place_of_modules = Standard(dict(
+    name="Commands should not be used in place of modules",
+    check=lintcheck('ANSIBLE0006,ANSIBLE0007'),
+    types=["playbook", "task", "handler"]
+))
+
+package_installs_should_not_use_latest = Standard(dict(
+    name="Package installs should use present, not latest",
+    check=lintcheck('ANSIBLE0010'),
+    types=["playbook", "task", "handler"]
+))
+
+use_shell_only_when_necessary = Standard(dict(
+    name="Shell should only be used when essential",
+    check=lintcheck('ANSIBLE0013'),
+    types=["playbook", "task", "handler"]
+))
+
+files_should_be_indented = Standard(dict(
+    name="YAML should be correctly indented",
+    check=yamlreview,
+    types=["playbook", "task", "handler", "rolevars",
+           "hostvars", "groupvars", "meta"]
+))
+
+inventory_must_parse = Standard(dict(
+    name="Inventory must be parseable",
+    check=parse,
+    types=["inventory"]
+))
+
+inventory_hostfiles_should_not_contain_vars = Standard(dict(
+    name="Inventory host files should not "
+         "contain variable stanzas ([group:vars])",
+    check=no_vars_in_host_file,
+    types=["inventory"]
+))
+
+code_should_meet_flake8 = Standard(dict(
+    name="Python code should pass flake8",
+    check=code_passes_flake8,
+    types=["code"]
+))
+
+tasks_are_named = Standard(dict(
+    name="Tasks and handlers must be named",
+    check=lintcheck('ANSIBLE0011'),
+    types=["playbook", "task", "handler"],
+))
+
+tasks_are_uniquely_named = Standard(dict(
+    name="Tasks and handlers must be uniquely named within a single file",
+    check=repeated_names,
+    types=["playbook", "task", "handler"],
+))
+
+vars_are_not_repeated_in_same_file = Standard(dict(
+    name="Vars should only occur once per file",
+    check=repeated_vars,
+    types=["rolevars", "hostvars", "groupvars"],
+))
+
+no_command_line_environment_variables = Standard(dict(
+    name="Environment variables should be passed through the environment key",
+    check=lintcheck('ANSIBLE0014'),
+    types=["playbook", "task", "handler"]
+))
+
+no_lineinfile = Standard(dict(
+    name="Lineinfile module should not be used as it suggests "
+         "more than one thing is managing a file",
+    check=lintcheck('EXTRA0002'),
+    types=["playbook", "task", "handler"]
+))
+
+become_rather_than_sudo = Standard(dict(
+    name="Use become/become_user/become_method rather than sudo/sudo_user",
+    check=lintcheck('ANSIBLE0008'),
+    types=["playbook", "task", "handler"]
+))
+
+use_yaml_rather_than_key_value = Standard(dict(
+    name="Use YAML format for tasks and handlers rather than key=value",
+    check=yaml_form_rather_than_key_value,
+    types=["playbook", "task", "handler"]
+))
+
+roles_scm_not_in_src = Standard(dict(
+    name="Use scm key rather than src: scm+url",
+    check=rolesfile_contains_scm_in_src,
+    types=["rolesfile"]
+))
+
+files_should_not_be_purposeless = Standard(dict(
+    name="Files should contain useful content",
+    check=files_should_have_actual_content,
+    types=["playbook", "task", "handler", "rolevars", "defaults", "meta"]
+))
+
+playbooks_should_not_contain_logic = Standard(dict(
+    name="Playbooks should not contain logic (vars, tasks, handlers)",
+    check=lintcheck('EXTRA0008'),
+    types=["playbook"]
+))
+
+host_vars_should_not_be_present = Standard(dict(
+    name="Host vars should not be present",
+    check=host_vars_exist,
+    types=["hostvars"]
+))
+
+with_items_bare_words = Standard(dict(
+    name="bare words are deprecated for with_items",
+    check=lintcheck('ANSIBLE0015'),
+    types=["task", "handler", "playbook"],
+    version="0.0"
+))
+
+file_permissions_are_octal = Standard(dict(
+    name="octal file permissions should start with a leading zero",
+    check=lintcheck('ANSIBLE0009'),
+    types=["task", "handler", "playbook"]
+))
+
+inventory_hostsfile_has_group_vars = Standard(dict(
+    name="inventory file should not contain group variables",
+    check=lintcheck('EXTRA0009'),
+    types=["inventory"]
+))
+
+inventory_hostsfile_has_host_vars = Standard(dict(
+    name="inventory file should not contain host variables "
+         "(except e.g. ansible_host, ansible_user, etc.)",
+    check=lintcheck('EXTRA0010'),
+    types=["inventory"]
+))
+
+test_matching_groupvar = Standard(dict(
+    check=same_variable_defined_in_competing_groups,
+    name="Same variable defined in siblings",
+    types=["groupvars"]
+))
+
+hosts_should_not_be_localhost = Standard(dict(
+    check=lintcheck('EXTRA0007'),
+    name="Use connection: local rather than hosts: localhost",
+    types=["playbook"]
+))
+
+# tasks_should_not_use_action =
+
+use_handlers_rather_than_when_changed = Standard(dict(
+    check=lintcheck('ANSIBLE0016'),
+    name="Use handlers rather than when: changed in tasks",
+    types=['task', 'playbook']
+))
+
+most_files_shouldnt_have_tabs = Standard(dict(
+    check=lintcheck('EXTRA0005'),
+    name="Don't use tabs in almost anything that isn't a Makefile",
+    types=["playbook", "task", "handler", "rolevars", "defaults", "meta",
+           "code", "groupvars", "hostvars", "inventory", "doc", "template",
+           "file"]
+))
+
+dont_delegate_to_localhost = Standard(dict(
+    check=lintcheck('EXTRA0004'),
+    name="Use connection: local rather than delegate_to: localhost",
+    types=["playbook", "task", "handler"]
+))
+
+become_user_should_have_become = Standard(dict(
+    check=lintcheck('ANSIBLE0017'),
+    name="become_user should be accompanied by become",
+    types=["playbook", "task", "handler"]
+))
+
+dont_compare_to_literal_bool = Standard(dict(
+    check=lintcheck('EXTRA0014'),
+    name="Don't compare to True or False - use `when: var` or `when: not var`",
+    types=["playbook", "task", "handler", "template"]
+))
+
+dont_compare_to_empty_string = Standard(dict(
+    check=lintcheck('EXTRA0015'),
+    name="Don't compare to \"\" - use `when: var` or `when: not var`",
+    types=["playbook", "task", "handler", "template"]
+))
+
+# Update this every time standards version increase
+latest_version = Standard(dict(
+    check=noop,
+    name="No-op check to ensure latest standards version is set",
+    version="0.1",
+    types=[]
+))
+
+
+standards = [
+    rolesfile_should_be_in_yaml,
+    role_must_contain_meta_main,
+    role_meta_main_must_contain_info,
+    become_rather_than_sudo,
+    variables_should_contain_whitespace,
+    commands_should_be_idempotent,
+    commands_should_not_be_used_in_place_of_modules,
+    package_installs_should_not_use_latest,
+    files_should_be_indented,
+    use_shell_only_when_necessary,
+    inventory_must_parse,
+    inventory_hostfiles_should_not_contain_vars,
+    code_should_meet_flake8,
+    tasks_are_named,
+    tasks_are_uniquely_named,
+    vars_are_not_repeated_in_same_file,
+    no_command_line_environment_variables,
+    no_lineinfile,
+    use_yaml_rather_than_key_value,
+    roles_scm_not_in_src,
+    files_should_not_be_purposeless,
+    playbooks_should_not_contain_logic,
+    host_vars_should_not_be_present,
+    with_items_bare_words,
+    file_permissions_are_octal,
+    inventory_hostsfile_has_host_vars,
+    inventory_hostsfile_has_group_vars,
+    test_matching_groupvar,
+    hosts_should_not_be_localhost,
+    dont_delegate_to_localhost,
+    most_files_shouldnt_have_tabs,
+    use_handlers_rather_than_when_changed,
+    become_user_should_have_become,
+    dont_compare_to_empty_string,
+    dont_compare_to_literal_bool,
+    latest_version,
+]

--- a/test/test_cases/test_role_errors/.yamllint
+++ b/test/test_cases/test_role_errors/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/test/test_cases/test_role_errors/README.md
+++ b/test/test_cases/test_role_errors/README.md
@@ -1,0 +1,48 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should
+be mentioned here. For instance, if the role uses the EC2 module, it may be a
+good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including
+any variables that are in defaults/main.yml, vars/main.yml, and any variables
+that can/should be set via parameters to the role. Any variables that are read
+from other roles and/or the global scope (ie. hostvars, group vars, etc.) should
+be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in
+regards to parameters that may need to be set for other roles, or variables that
+are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables
+passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: tryit, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a
+website (HTML is not allowed).

--- a/test/test_cases/test_role_errors/defaults/main.yml
+++ b/test/test_cases/test_role_errors/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for tryit
+things:
+   - thing one
+    - thing two

--- a/test/test_cases/test_role_errors/handlers/main.yml
+++ b/test/test_cases/test_role_errors/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for tryit

--- a/test/test_cases/test_role_errors/meta/main.yml
+++ b/test/test_cases/test_role_errors/meta/main.yml
@@ -1,0 +1,58 @@
+---
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.

--- a/test/test_cases/test_role_errors/tasks/main.yml
+++ b/test/test_cases/test_role_errors/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# tasks file for tryit
+
+- command: yum install epel
+  register: yum_out
+
+- debug: var=yum_out

--- a/test/test_cases/test_role_errors/vars/main.yml
+++ b/test/test_cases/test_role_errors/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for tryit


### PR DESCRIPTION
Makes output handling pluggable, allowing for the addition of new output handlers, such as the included JSON structured handler. 

- Moves default output to Python logging
- Adds `-f` format output option
- Adds JSON output handler using structlog
- Fixes a bug in `yamlindent`
- Adds unit tests

### Default Output

The default output behavior continues to work. There's no change to the user experience, and color output is sent to the display, as the following demonstrates:

```bash
$ find . -type f -not -path './molecule/*' | xargs ansible-review
```

```bash
WARN: No configuration file found at /Users/chouseknecht/Library/Application Support/ansible-review/config.ini
WARN: Using example standards found at /Users/chouseknecht/projects/ansible-review/lib/ansiblereview/examples
WARN: Using example lint-rules found at /Users/chouseknecht/projects/ansible-review/lib/ansiblereview/examples/lint-rules
WARN: RoleVars ./vars/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Best practice "Files should contain useful content" not met:
./vars/main.yml:RoleVars (./vars/main.yml) appears to have no useful content
WARN: Task ./tasks/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Best practice "Commands should be idempotent" not met:
./tasks/main.yml:4: [ANSIBLE0012] Commands should not change things if nothing needs doing
WARN: Best practice "Commands should not be used in place of modules" not met:
./tasks/main.yml:4: [ANSIBLE0006] yum used in place of yum module
WARN: Best practice "Tasks and handlers must be named" not met:
./tasks/main.yml:4: [ANSIBLE0011] All tasks should be named
WARN: Best practice "Use YAML format for tasks and handlers rather than key=value" not met:
./tasks/main.yml:7: Task arguments appear to be in key value rather than YAML format
WARN: Meta ./meta/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Best practice "Roles meta/main.yml must contain important info" not met:
./meta/main.yml:1: [EXTRA0013] role info should contain platforms
WARN: RoleVars ./defaults/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Best practice "Files should contain useful content" not met:
./defaults/main.yml:RoleVars (./defaults/main.yml) appears to have no useful content
WARN: Handler ./handlers/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Best practice "Files should contain useful content" not met:
./handlers/main.yml:Handler (./handlers/main.yml) appears to have no useful content
```

### JSON Output

Using the `-f json` option, it's now possible to get structured output that can potentially be parsed by third party tools and log aggregators, as demonstrated here:

```bash
$ find . -type f -not -path './molecule/*' | xargs ansible-review -f json
```

```yaml
{"event": "No configuration file found at /Users/chouseknecht/Library/Application Support/ansible-review/config.ini", "level": "warning", "tag": "config", "timestamp": "2018-07-07T05:26:52.871032Z"}
{"event": "Using example standards found at /Users/chouseknecht/projects/ansible-review/lib/ansiblereview/examples", "level": "warning", "tag": "config", "timestamp": "2018-07-07T05:26:52.871487Z"}
{"event": "Using example lint-rules found at /Users/chouseknecht/projects/ansible-review/lib/ansiblereview/examples/lint-rules", "level": "warning", "tag": "config", "timestamp": "2018-07-07T05:26:52.881395Z"}
{"event": "RoleVars ./vars/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1", "file": "./vars/main.yml", "level": "warning", "tag": "standards_version", "timestamp": "2018-07-07T05:26:52.894204Z"}
{"event": "Best practice \"Files should contain useful content\" not met:\n./vars/main.yml:RoleVars (./vars/main.yml) appears to have no useful content", "file": "./vars/main.yml", "level": "warning", "lineno": null, "message": "RoleVars (./vars/main.yml) appears to have no useful content", "passed": false, "standard": "Files should contain useful content", "tag": "review", "timestamp": "2018-07-07T05:26:52.902816Z"}
{"event": "Task ./tasks/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1", "file": "./tasks/main.yml", "level": "warning", "tag": "standards_version", "timestamp": "2018-07-07T05:26:52.909610Z"}
{"error_msg": "Commands should not change things if nothing needs doing", "error_rule": "ANSIBLE0012", "error_type": "ansiblelint", "event": "Best practice \"Commands should be idempotent\" not met:\n./tasks/main.yml:4: [ANSIBLE0012] Commands should not change things if nothing needs doing", "file": "./tasks/main.yml", "level": "warning", "lineno": 4, "message": "[ANSIBLE0012] Commands should not change things if nothing needs doing", "passed": false, "standard": "Commands should be idempotent", "tag": "review", "timestamp": "2018-07-07T05:26:53.043036Z"}
{"error_msg": "yum used in place of yum module", "error_rule": "ANSIBLE0006", "error_type": "ansiblelint", "event": "Best practice \"Commands should not be used in place of modules\" not met:\n./tasks/main.yml:4: [ANSIBLE0006] yum used in place of yum module", "file": "./tasks/main.yml", "level": "warning", "lineno": 4, "message": "[ANSIBLE0006] yum used in place of yum module", "passed": false, "standard": "Commands should not be used in place of modules", "tag": "review", "timestamp": "2018-07-07T05:26:53.052665Z"}
{"error_msg": "All tasks should be named", "error_rule": "ANSIBLE0011", "error_type": "ansiblelint", "event": "Best practice \"Tasks and handlers must be named\" not met:\n./tasks/main.yml:4: [ANSIBLE0011] All tasks should be named", "file": "./tasks/main.yml", "level": "warning", "lineno": 4, "message": "[ANSIBLE0011] All tasks should be named", "passed": false, "standard": "Tasks and handlers must be named", "tag": "review", "timestamp": "2018-07-07T05:26:53.074791Z"}
{"event": "Best practice \"Use YAML format for tasks and handlers rather than key=value\" not met:\n./tasks/main.yml:7: Task arguments appear to be in key value rather than YAML format", "file": "./tasks/main.yml", "level": "warning", "lineno": 7, "message": "Task arguments appear to be in key value rather than YAML format", "passed": false, "standard": "Use YAML format for tasks and handlers rather than key=value", "tag": "review", "timestamp": "2018-07-07T05:26:53.091319Z"}
{"event": "Meta ./meta/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1", "file": "./meta/main.yml", "level": "warning", "tag": "standards_version", "timestamp": "2018-07-07T05:26:53.142825Z"}
{"error_msg": "role info should contain platforms", "error_rule": "EXTRA0013", "error_type": "ansiblelint", "event": "Best practice \"Roles meta/main.yml must contain important info\" not met:\n./meta/main.yml:1: [EXTRA0013] role info should contain platforms", "file": "./meta/main.yml", "level": "warning", "lineno": 1, "message": "[EXTRA0013] role info should contain platforms", "passed": false, "standard": "Roles meta/main.yml must contain important info", "tag": "review", "timestamp": "2018-07-07T05:26:53.163122Z"}
{"event": "RoleVars ./defaults/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1", "file": "./defaults/main.yml", "level": "warning", "tag": "standards_version", "timestamp": "2018-07-07T05:26:53.180206Z"}
{"event": "Best practice \"Files should contain useful content\" not met:\n./defaults/main.yml:RoleVars (./defaults/main.yml) appears to have no useful content", "file": "./defaults/main.yml", "level": "warning", "lineno": null, "message": "RoleVars (./defaults/main.yml) appears to have no useful content", "passed": false, "standard": "Files should contain useful content", "tag": "review", "timestamp": "2018-07-07T05:26:53.186324Z"}
{"event": "Handler ./handlers/main.yml is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1", "file": "./handlers/main.yml", "level": "warning", "tag": "standards_version", "timestamp": "2018-07-07T05:26:53.192419Z"}
{"event": "Best practice \"Files should contain useful content\" not met:\n./handlers/main.yml:Handler (./handlers/main.yml) appears to have no useful content", "file": "./handlers/main.yml", "level": "warning", "lineno": null, "message": "Handler (./handlers/main.yml) appears to have no useful content", "passed": false, "standard": "Files should contain useful content", "tag": "review", "timestamp": "2018-07-07T05:26:53.232110Z"}
```