### PR TITLE
fix TestDiffEncoding when run in C locale

### DIFF
--- a/test/TestDiffEncoding.py
+++ b/test/TestDiffEncoding.py
@@ -9,7 +9,7 @@ class TestDiffEncoding(unittest.TestCase):
     
     def test_diff_encoding(self):
         difflines = []
-        with io.open(os.path.join(self.directory, 'diff.txt'), 'r') as f:
+        with io.open(os.path.join(self.directory, 'diff.txt'), 'r', encoding='utf-8') as f:
             for line in f.readlines():
                 encodedline = line.encode("utf-8")
                 difflines.append(encodedline)


### PR DESCRIPTION
On Python 2 when the locale uses ASCII (for example, inside Fedora's
Koji build system) io.open will try to decode the file as ASCII instead
of UTF-8, which causes the test to fail:

    ======================================================================
    ERROR: test_diff_encoding (TestDiffEncoding.TestDiffEncoding)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/ansible-review-0.13.7/test/TestDiffEncoding.py", line 13, in test_diff_encoding
        for line in f.readlines():
      File "/usr/lib64/python2.7/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 114: ordinal not in range(128)

The file is UTF-8 and the test is clearly expecting that so explicitly
specify the encoding when opening the file.