### PR TITLE
groupvars: InventoryManager get_group() and get_group_vars() changes

### DIFF
--- a/lib/ansiblereview/groupvars.py
+++ b/lib/ansiblereview/groupvars.py
@@ -73,7 +73,10 @@ def same_variable_defined_in_competing_groups(candidate, options):
         result.errors = [Error(None, "Inventory is broken: %s" % e.message)]
         return result
 
-    group = inv.get_group(os.path.basename(candidate.path))
+    if hasattr(inv, 'groups'):
+        group = inv.groups.get(os.path.basename(candidate.path))
+    else:
+        group = inv.get_group(os.path.basename(candidate.path))
     if not group:
         # group file exists in group_vars but no related group
         # in inventory directory

--- a/lib/ansiblereview/groupvars.py
+++ b/lib/ansiblereview/groupvars.py
@@ -21,6 +21,11 @@ _inv = None
 
 
 def get_group_vars(group, inventory):
+    try:
+        from ansible.inventory.helpers import get_group_vars
+        return get_group_vars(inventory.groups.values())
+    except ImportError:
+        pass
     # http://stackoverflow.com/a/197053
     vars = inspect.getargspec(inventory.get_group_vars)
     if 'return_results' in vars[0]:


### PR DESCRIPTION
The first commit deals with the lack of get_group() on `InventoryManager`.

The second commit deals with the move of get_group_vars() to `ansible.inventory.helpers`