### PR TITLE
Migrate from pep8 to pycodestlye

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     - language: python
       python: "2.7"
-      env: TOXENV=py27-flake8
+      env: TOXENV=py27-lint
 
     - language: python
       python: "2.7"
@@ -68,10 +68,12 @@ matrix:
 
     - language: python
       python: "3.6"
-      env: TOXENV=py36-flake8
+      env: TOXENV=py36-lint
 
 install:
   - pip install -r test-deps.txt
+  # fail if installation introduced conflicts (pip check)
+  - pip check
 
 script:
 - tox -v

--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -226,7 +226,7 @@ def ansiblelint(rulename, candidate, settings):
     return result
 
 
-def find_version(filename, version_regex="^# Standards: ([0-9]+\.[0-9]+)"):
+def find_version(filename, version_regex=r"^# Standards: ([0-9]+\.[0-9]+)"):
     version_re = re.compile(version_regex)
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
         for line in f:

--- a/lib/ansiblereview/code.py
+++ b/lib/ansiblereview/code.py
@@ -1,8 +1,8 @@
 from ansiblereview import Error, Result, utils
 
 
-def code_passes_flake8(candidate, options):
-    result = utils.execute(["flake8", candidate.path])
+def code_passes_pycodestyle(candidate, options):
+    result = utils.execute(["pycodestyle", candidate.path])
     errors = []
     if result.rc:
         for line in result.output.strip().split('\n'):

--- a/lib/ansiblereview/examples/standards.py
+++ b/lib/ansiblereview/examples/standards.py
@@ -5,7 +5,7 @@ import yaml
 from ansiblereview import Result, Error, Standard, lintcheck
 from ansiblereview.utils.yamlindent import yamlreview
 from ansiblereview.inventory import parse, no_vars_in_host_file
-from ansiblereview.code import code_passes_flake8
+from ansiblereview.code import code_passes_pycodestyle
 from ansiblereview.vars import repeated_vars
 from ansiblereview.playbook import repeated_names
 from ansiblereview.rolesfile import yamlrolesfile
@@ -118,9 +118,9 @@ inventory_hostfiles_should_not_contain_vars = Standard(dict(
     types=["inventory"]
 ))
 
-code_should_meet_flake8 = Standard(dict(
-    name="Python code should pass flake8",
-    check=code_passes_flake8,
+code_should_meet_pycodestyle = Standard(dict(
+    name="Python code should pass pycodestyle",
+    check=code_passes_pycodestyle,
     types=["code"]
 ))
 
@@ -294,7 +294,7 @@ standards = [
     use_shell_only_when_necessary,
     inventory_must_parse,
     inventory_hostfiles_should_not_contain_vars,
-    code_should_meet_flake8,
+    code_should_meet_pycodestyle,
     tasks_are_named,
     tasks_are_uniquely_named,
     vars_are_not_repeated_in_same_file,

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -40,7 +40,7 @@ from ansiblereview import Result, Error, utils
 
 def indent_checker(filename):
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
-        indent_regex = re.compile("^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
+        indent_regex = re.compile(r"^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
         lineno = 0
         prev_indent = ''
         errors = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 description-file = README.md
 
-[flake8]
+[pycodestyle]
 max-line-length = 100
 exclude = .git,.hg,.svn,test,setup.py,__pycache__

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages('lib'),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['ansible-lint>=3.4.1', 'pyyaml', 'appdirs', 'unidiff', 'flake8'],
+    install_requires=['ansible-lint>=3.4.1', 'pyyaml', 'appdirs', 'unidiff', 'pycodestyle'],
     entry_points={
         'console_scripts': [
             'ansible-review = ansiblereview.__main__:main'

--- a/test-deps.txt
+++ b/test-deps.txt
@@ -1,4 +1,4 @@
-flake8
+pycodestyle
 nose
 pep8-naming
 tox

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -38,8 +38,8 @@ class TestUtils(unittest.TestCase):
                                       'tasks', 'main.yml'))
         self.assertEqual(candidate.version, '0.2')
 
-    def test_code_passes_flake8(self):
-        # run flake8 against this source file
+    def test_code_passes_pycodestyle(self):
+        # run pycodestyle against this source file
         candidate = Code(__file__.replace('.pyc', '.py'))
-        result = code.code_passes_flake8(candidate, None)
+        result = code.code_passes_pycodestyle(candidate, None)
         self.assertEqual(len(result.errors), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27-ansible{19,20,21},py{27,36}-ansible{22,23,24,25,devel},py{27,36}-flake8
+envlist = py27-ansible{19,20,21},py{27,36}-ansible{22,23,24,25,devel},py{27,36}-lint
 
 [testenv]
 deps =
@@ -17,10 +17,10 @@ deps =
 commands = nosetests []
 passenv = HOME
 
-[testenv:py27-flake8]
-commands = flake8 lib
+[testenv:py27-lint]
+commands = pycodestyle lib
 usedevelop = True
 
-[testenv:py36-flake8]
-commands = flake8 lib
+[testenv:py36-lint]
+commands = pycodestyle lib
 usedevelop = True


### PR DESCRIPTION
pep8 was renamed to pycodestyle long time ago and for compatibility
the old package would install pycodetyle but only a specific version
which may cause conflicts with other tools

This change adopts pycodestyle so we would avoid dependency conflicts.

At the same time, we introduced a 'pip check' execution in CI in
order to spot future conflicts that could be introduced by
the installation of ansible-review.