### PR TITLE
Fix reading from stdin under Python 3

### DIFF
--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -226,7 +226,7 @@ def ansiblelint(rulename, candidate, settings):
     return result
 
 
-def find_version(filename, version_regex="^# Standards: ([0-9]+\.[0-9]+)"):
+def find_version(filename, version_regex=r"^# Standards: ([0-9]+\.[0-9]+)"):
     version_re = re.compile(version_regex)
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
         for line in f:

--- a/lib/ansiblereview/__main__.py
+++ b/lib/ansiblereview/__main__.py
@@ -73,7 +73,11 @@ def main():
                 options.lintdir = lint_dir
 
     if len(args) == 0:
-        candidates = get_candidates_from_diff(sys.stdin)
+        buf = sys.stdin
+        if sys.version_info[0] == 3:
+            """Bypass bytes to unidiff regardless."""
+            buf = buf.buffer
+        candidates = get_candidates_from_diff(buf)
     else:
         candidates = args
 

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -40,7 +40,7 @@ from ansiblereview import Result, Error, utils
 
 def indent_checker(filename):
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
-        indent_regex = re.compile("^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
+        indent_regex = re.compile(r"^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
         lineno = 0
         prev_indent = ''
         errors = []

--- a/test-deps.txt
+++ b/test-deps.txt
@@ -1,4 +1,5 @@
 flake8
+mock
 nose
 pep8-naming
 tox

--- a/test/TestDiffEncoding.py
+++ b/test/TestDiffEncoding.py
@@ -1,7 +1,25 @@
 import unittest
 import os
+import sys
 import io
+import mock
 import ansiblereview.__main__ as main
+
+
+def patch_stdin_with(file_name):
+    def decorator(func):
+        def stdin_patcher(*args, **kwargs):
+            with io.open(file_name, 'rb') as f:
+                mock_stream = (
+                    io.TextIOWrapper if sys.version_info[0] == 3
+                    else io.BufferedReader
+                )(f)
+
+                with mock.patch.object(sys, 'stdin', mock_stream):
+                    return func(*args, **kwargs)
+        return stdin_patcher
+    return decorator
+
 
 class TestDiffEncoding(unittest.TestCase):
 
@@ -15,3 +33,9 @@ class TestDiffEncoding(unittest.TestCase):
                 difflines.append(encodedline)
             candidate = main.get_candidates_from_diff(difflines)
             self.assertEqual(len(candidate), 1)
+
+    @mock.patch.object(sys, 'argv', [sys.argv[0]])  # Enter stdin read mode
+    @patch_stdin_with(os.path.join(directory, 'diff.txt'))
+    def test_diff_stdin_encoding(self):
+        errors_num = main.main()
+        assert errors_num == 0


### PR DESCRIPTION
Unidiff tries to decode input internally.
Under Python3 sys.stdin emits unicode strings, but underlying bytes
are available under the buffer property.

Current version of ansible-review:
```python-traceback
$ git diff master... | ansible-review                                                                                                
WARN: No configuration file found at ~/.config/ansible-review/config.ini
WARN: Using example standards found at ~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/examples
WARN: Using example lint-rules found at ~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/examples/lint-rules
Traceback (most recent call last):
  File "~/.pyenv/versions/ansiwatch-bot-py3.7.1-pyenv-venv/bin/ansible-review", line 11, in <module>
    sys.exit(main())
  File "~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/__main__.py", line 76, in main
    candidates = get_candidates_from_diff(sys.stdin)
  File "~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/__main__.py", line 20, in get_candidates_from_diff
    patch = unidiff.PatchSet(difftext, encoding='utf-8')
  File "~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/unidiff/patch.py", line 353, in __init__
    self._parse(data, encoding=encoding)
  File "~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/unidiff/patch.py", line 368, in _parse
    line = line.decode(encoding)
AttributeError: 'str' object has no attribute 'decode'
```

Version `ansible-review` with this patch:
```python-traceback
$ git diff master... | ansible-review            
WARN: No configuration file found at ~/.config/ansible-review/config.ini
WARN: Using example standards found at ~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/examples
WARN: Using example lint-rules found at ~/.pyenv/versions/3.7.1/envs/ansiwatch-bot-py3.7.1-pyenv-venv/lib/python3.7/site-packages/ansiblereview/examples/lint-rules
WARN: Template molecule/default/Dockerfile.j2 is in a role that contains a meta/main.yml without a declared standards version. Using latest standards version 0.1
WARN: Playbook molecule/default/molecule.yml does not present standards version. Using latest standards version 0.1
WARN: Playbook molecule/default/playbook.yml does not present standards version. Using latest standards version 0.1
WARN: Playbook configure-userspace.yml does not present standards version. Using latest standards version 0.1
WARN: Best practice "Playbooks should not contain logic (vars, tasks, handlers)" not met:
configure-userspace.yml:2: [EXTRA0008] tasks should not be required in a play
```