### PR TITLE
Fix regular expression escape sequences

### DIFF
--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -226,7 +226,7 @@ def ansiblelint(rulename, candidate, settings):
     return result
 
 
-def find_version(filename, version_regex="^# Standards: ([0-9]+\.[0-9]+)"):
+def find_version(filename, version_regex=r"^# Standards: ([0-9]+\.[0-9]+)"):
     version_re = re.compile(version_regex)
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
         for line in f:

--- a/lib/ansiblereview/utils/yamlindent.py
+++ b/lib/ansiblereview/utils/yamlindent.py
@@ -40,7 +40,7 @@ from ansiblereview import Result, Error, utils
 
 def indent_checker(filename):
     with codecs.open(filename, mode='rb', encoding='utf-8') as f:
-        indent_regex = re.compile("^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
+        indent_regex = re.compile(r"^(?P<indent>\s*(?:- )?)(?P<rest>.*)$")
         lineno = 0
         prev_indent = ''
         errors = []


### PR DESCRIPTION
Use raw strings so that regexes work correctly