### PR TITLE
lib/ansiblereview/__init__.py: Fix group_vars and host_vars classification (#60)

### DIFF
--- a/lib/ansiblereview/__init__.py
+++ b/lib/ansiblereview/__init__.py
@@ -182,9 +182,9 @@ def classify(filename):
         return Handler(filename)
     if parentdir in ['vars', 'defaults']:
         return RoleVars(filename)
-    if parentdir in ['group_vars']:
+    if 'group_vars' in os.path.dirname(filename).split(os.sep):
         return GroupVars(filename)
-    if parentdir in ['host_vars']:
+    if 'host_vars' in os.path.dirname(filename).split(os.sep):
         return HostVars(filename)
     if parentdir == 'meta':
         return Meta(filename)


### PR DESCRIPTION

There are two ways of defining variable files:
- using a YAML file named after the group/host name
- using a directory named after the group/host name containing one or more YAML
  file.

Currently the code only handle the first case. Try to improve the check
by looking for group_vars/host_vars in the candidate file path.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>