### PR TITLE
Allow ansible-review to read yaml containing inline vault strings

### DIFF
--- a/lib/ansiblereview/examples/standards.py
+++ b/lib/ansiblereview/examples/standards.py
@@ -2,6 +2,8 @@ import codecs
 import os
 import yaml
 
+from yaml.loader import SafeLoader
+
 from ansiblereview import Result, Error, Standard, lintcheck
 from ansiblereview.utils.yamlindent import yamlreview
 from ansiblereview.inventory import parse, no_vars_in_host_file
@@ -13,6 +15,11 @@ from ansiblereview.tasks import yaml_form_rather_than_key_value
 from ansiblereview.groupvars import same_variable_defined_in_competing_groups
 from ansiblelint.utils import parse_yaml_linenumbers
 
+def vault_stub_constructor(loader, node):
+    return loader.construct_scalar(node)
+
+SafeLoader.add_constructor(u'!vault', vault_stub_constructor)
+SafeLoader.add_constructor(u'!vault-encrypted', vault_stub_constructor)
 
 def rolesfile_contains_scm_in_src(candidate, settings):
     result = Result(candidate.path)


### PR DESCRIPTION
When passing var files to `ansible-review` which contain inlined vault-encrypted values, like the following:

```
password: !vault |
  $ANSIBLE_VAULT;1.1;AES256
  ...
```

The default standards will throw an error:

```
yaml.constructor.ConstructorError: could not determine a constructor for the tag '!vault'
  in "<unicode string>", line 29, column 24:
    password: !vault |
```

This is because `yaml.safe_load` is used to avoid remote code execution from running on untrusted yaml.

This patch adds a stub constructor to the yaml `SafeLoader` for `!vault` and `!vault-encrypted` items, and simply returns the scalar value of the node (i.e. the encrypted string).

It may or may not be necessary to return the (still-encrypted) value for the purposes of `ansible-review` but I've left it in for the moment.