### PR TITLE
Cope with Ansible >= 2.4 inventory changes

### DIFF
--- a/lib/ansiblereview/inventory.py
+++ b/lib/ansiblereview/inventory.py
@@ -38,5 +38,9 @@ def parse(candidate, options):
         else:
             ansible.inventory.Inventory(candidate.path)
     except Exception as e:
-        result.errors = [Error(None, "Inventory is broken: %s" % e.message)]
+        if hasattr(e, 'message'):
+            message = e.message
+        else:
+            message = str(e)
+        result.errors = [Error(None, "Inventory is broken: %s" % message)]
     return result

--- a/lib/ansiblereview/inventory.py
+++ b/lib/ansiblereview/inventory.py
@@ -5,14 +5,14 @@ import yaml
 
 try:
     import ansible.parsing.dataloader
-    from ansible.vars.manager import VariableManager
-    ANSIBLE = 2
 except ImportError:
+    ANSIBLE = 1
+else:
+    ANSIBLE = 2
     try:
-        from ansible.vars import VariableManager
-        ANSIBLE = 2
+        from ansible.vars.manager import VariableManager
     except ImportError:
-        ANSIBLE = 1
+        from ansible.vars import VariableManager
 
 
 def no_vars_in_host_file(candidate, options):

--- a/lib/ansiblereview/utils/__init__.py
+++ b/lib/ansiblereview/utils/__init__.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 
 try:
-    import ConfigParser as configparser
+    import ConfigParser as configparser  # noqa: N813
 except ImportError:
     import configparser
 


### PR DESCRIPTION
This is to deal with changes in Ansible 2.4 which removed `ansible.inventory.Inventory`, apparently to be replaced by `ansible.inventory.manager.InventoryManager`.

Here's how it behaved without the changes in this PR:

````
(ansible-review) nils@gibraltar:~/src/fedora-infra/ansible (master)> ansible-review inventory/builders 
WARN: No configuration file found at /home/nils/.config/ansible-review/config.ini
WARN: Using example standards found at /home/nils/src/ansible-review/lib/ansiblereview/examples
WARN: Using example lint-rules found at /home/nils/src/ansible-review/lib/ansiblereview/examples/lint-rules
Traceback (most recent call last):
  File "/home/nils/src/ansible-review/lib/ansiblereview/inventory.py", line 36, in parse
    ansible.inventory.Inventory(loader=loader, variable_manager=var_manager,
AttributeError: module 'ansible.inventory' has no attribute 'Inventory'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nils/.virtualenvs/ansible-review/bin/ansible-review", line 11, in <module>
    load_entry_point('ansible-review', 'console_scripts', 'ansible-review')()
  File "/home/nils/src/ansible-review/lib/ansiblereview/__main__.py", line 99, in main
    errors = errors + candidate.review(options, lines)
  File "/home/nils/src/ansible-review/lib/ansiblereview/__init__.py", line 76, in review
    return utils.review(self, settings, lines)
  File "/home/nils/src/ansible-review/lib/ansiblereview/utils/__init__.py", line 120, in review
    result = standard.check(candidate, settings)
  File "/home/nils/src/ansible-review/lib/ansiblereview/inventory.py", line 41, in parse
    result.errors = [Error(None, "Inventory is broken: %s" % e.message)]
AttributeError: 'AttributeError' object has no attribute 'message'
(ansible-review) nils@gibraltar:~/src/fedora-infra/ansible (master)>
````

This PR also lets ansible-review cope with exceptions caught that don't have a `message` attribute.