### PR TITLE
adding option to allow skipping via tag on yaml_form_rather_than_key_…

### DIFF
--- a/lib/ansiblereview/tasks.py
+++ b/lib/ansiblereview/tasks.py
@@ -19,6 +19,11 @@ def yaml_form_rather_than_key_value(candidate, settings):
                 continue
             if isinstance(task[action], dict):
                 continue
+            # allow skipping based on tag e.g. if using splatting
+            # https://docs.ansible.com/ansible/devel/reference_appendices\
+            # /faq.html#argsplat-unsafe
+            if 'skip_ansible_lint' in (task.get('tags') or []):
+                continue
             # strip additional newlines off task[action]
             if task[action].strip().split() != arguments:
                 errors.append(Error(task['__line__'], "Task arguments appear "


### PR DESCRIPTION
In one of our testing roles we using [splatting](https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#argsplat-unsafe) to pass module arguments en bloc.  This is very convenient for our particular use case.  However, when we run ansible-review against the code we get:

```
Task arguments appear to be in key value rather than YAML format
```
An example piece of code is as follows:
```
- name: Create OpenStack instance
  os_server: "{{ os_server_parameters }}"
  register: os_server_create
```
With this PR we are able to bypass the warning:
```
- name: Create OpenStack instance
  os_server: "{{ os_server_parameters }}"
  register: os_server_create
  tags:
  - skip_ansible_lint
```