### PR TITLE
Don't pop from currently iterated dict

### DIFF
--- a/lib/ansiblereview/groupvars.py
+++ b/lib/ansiblereview/groupvars.py
@@ -38,12 +38,15 @@ def remove_inherited_and_overridden_vars(vars, group, inventory):
     if group not in _vars:
         _vars[group] = get_group_vars(group, inventory)
     gv = _vars[group]
+    keys_to_pop = []
     for (k, v) in vars.items():
         if k in gv:
             if gv[k] == v:
-                vars.pop(k)
+                keys_to_pop.append(k)
             else:
                 gv.pop(k)
+    for k in keys_to_pop:
+        vars.pop(k)
 
 
 def remove_inherited_and_overridden_group_vars(group, inventory):


### PR DESCRIPTION
Avoids: "RuntimeError: dictionary changed size during iteration"

Context: https://fedora.softwarefactory-project.io/zuul/build/c5d36ac22ef741b4b2e5abb2f7a8cd29

````
Traceback (most recent call last):
  File "/usr/bin/ansible-review", line 11, in <module>
    load_entry_point('ansible-review==0.13.9', 'console_scripts', 'ansible-review')()
  File "/usr/lib/python3.7/site-packages/ansiblereview/__main__.py", line 99, in main
    errors = errors + candidate.review(options, lines)
  File "/usr/lib/python3.7/site-packages/ansiblereview/__init__.py", line 76, in review
    return utils.review(self, settings, lines)
  File "/usr/lib/python3.7/site-packages/ansiblereview/utils/__init__.py", line 120, in review
    result = standard.check(candidate, settings)
  File "/usr/lib/python3.7/site-packages/ansiblereview/groupvars.py", line 89, in same_variable_defined_in_competing_groups
    remove_inherited_and_overridden_group_vars(group, inv)
  File "/usr/lib/python3.7/site-packages/ansiblereview/groupvars.py", line 53, in remove_inherited_and_overridden_group_vars
    remove_inherited_and_overridden_vars(_vars[group], ancestor, inventory)
  File "/usr/lib/python3.7/site-packages/ansiblereview/groupvars.py", line 41, in remove_inherited_and_overridden_vars
    for (k, v) in vars.items():
RuntimeError: dictionary changed size during iteration
````