### PR TITLE
Fix cannot import name 'default_rulesdir' from 'ansiblelint'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages('lib'),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['ansible-lint>=3.4.1', 'pyyaml', 'appdirs', 'unidiff', 'flake8'],
+    install_requires=['ansible-lint==4.3.0', 'pyyaml', 'appdirs', 'unidiff', 'flake8'],
     entry_points={
         'console_scripts': [
             'ansible-review = ansiblereview.__main__:main'


### PR DESCRIPTION
Fixes #91. Pin the ansible-lint version.
Current version 4.3.1 refactor *default_rulesdir* away.